### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -20,3 +20,5 @@
 ^CLAUDE\.md$
 ^\.claude$
 ^test-data$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/chk.R
+++ b/R/chk.R
@@ -99,7 +99,9 @@ xname <- function(x, col) {
       years = paste(.data$CaribouYear, collapse = ", "),
       .by = "PopulationName"
     ) |>
-    dplyr::mutate(part = paste0(.data$PopulationName, " (", .data$years, ")")) |>
+    dplyr::mutate(
+      part = paste0(.data$PopulationName, " (", .data$years, ")")
+    ) |>
     dplyr::pull("part")
 
   message(
@@ -135,28 +137,40 @@ xname <- function(x, col) {
 
   details <- character(0)
   if (length(pops_sur_only)) {
-    details <- c(details, paste0(
-      "Populations in survival only: ",
-      paste(pops_sur_only, collapse = ", ")
-    ))
+    details <- c(
+      details,
+      paste0(
+        "Populations in survival only: ",
+        paste(pops_sur_only, collapse = ", ")
+      )
+    )
   }
   if (length(pops_rec_only)) {
-    details <- c(details, paste0(
-      "Populations in recruitment only: ",
-      paste(pops_rec_only, collapse = ", ")
-    ))
+    details <- c(
+      details,
+      paste0(
+        "Populations in recruitment only: ",
+        paste(pops_rec_only, collapse = ", ")
+      )
+    )
   }
   if (length(years_sur_only)) {
-    details <- c(details, paste0(
-      "CaribouYears in survival only: ",
-      paste(years_sur_only, collapse = ", ")
-    ))
+    details <- c(
+      details,
+      paste0(
+        "CaribouYears in survival only: ",
+        paste(years_sur_only, collapse = ", ")
+      )
+    )
   }
   if (length(years_rec_only)) {
-    details <- c(details, paste0(
-      "CaribouYears in recruitment only: ",
-      paste(years_rec_only, collapse = ", ")
-    ))
+    details <- c(
+      details,
+      paste0(
+        "CaribouYears in recruitment only: ",
+        paste(years_rec_only, collapse = ", ")
+      )
+    )
   }
   message(
     "Filtering to shared population and year combinations. ",

--- a/R/fit-recruitment-ml.R
+++ b/R/fit-recruitment-ml.R
@@ -105,7 +105,10 @@ bb_fit_recruitment_ml <- function(
   fit$data <- data$data
   code_constants <- c(priors_recruitment(), sex_ratio = sex_ratio)
   if (!is.null(adult_female_proportion)) {
-    code_constants <- c(code_constants, adult_female_prop = adult_female_proportion)
+    code_constants <- c(
+      code_constants,
+      adult_female_prop = adult_female_proportion
+    )
   }
   fit$model_code <- clean_model_code(
     substitute_prior_values(model$getCode(), code_constants)

--- a/R/fit-recruitment.R
+++ b/R/fit-recruitment.R
@@ -130,9 +130,15 @@ bb_fit_recruitment <- function(
   fit$data <- data$data
   code_constants <- c(priors, sex_ratio = sex_ratio)
   if (!is.null(adult_female_proportion)) {
-    code_constants <- c(code_constants, adult_female_prop = adult_female_proportion)
+    code_constants <- c(
+      code_constants,
+      adult_female_prop = adult_female_proportion
+    )
   }
-  fit$model_code <- clean_model_code(substitute_prior_values(model$getCode(), code_constants))
+  fit$model_code <- clean_model_code(substitute_prior_values(
+    model$getCode(),
+    code_constants
+  ))
   class(fit) <- c("bboufit_recruitment", "bboufit")
   fit
 }

--- a/R/fit-survival-ml.R
+++ b/R/fit-survival-ml.R
@@ -109,7 +109,10 @@ bb_fit_survival_ml <- function(
   .attrs_bboufit_ml(fit) <- attrs
 
   fit$data <- data$data
-  fit$model_code <- clean_model_code(substitute_prior_values(model$getCode(), priors_survival()))
+  fit$model_code <- clean_model_code(substitute_prior_values(
+    model$getCode(),
+    priors_survival()
+  ))
   class(fit) <- c("bboufit_survival", "bboufit_ml")
   fit
 }

--- a/R/fit-survival.R
+++ b/R/fit-survival.R
@@ -136,7 +136,10 @@ bb_fit_survival <- function(
 
   .attrs_bboufit(fit) <- attrs
   fit$data <- data$data
-  fit$model_code <- clean_model_code(substitute_prior_values(model$getCode(), priors))
+  fit$model_code <- clean_model_code(substitute_prior_values(
+    model$getCode(),
+    priors
+  ))
   class(fit) <- c("bboufit_survival", "bboufit")
   fit
 }

--- a/R/model-recruitment.R
+++ b/R/model-recruitment.R
@@ -23,8 +23,15 @@ model_data_recruitment <- function(
   quiet
 ) {
   if (allow_missing) {
-    measurement_cols <- c("Cows", "Bulls", "UnknownAdults", "Yearlings", "Calves")
-    placeholder <- rowSums(is.na(data[measurement_cols])) == length(measurement_cols)
+    measurement_cols <- c(
+      "Cows",
+      "Bulls",
+      "UnknownAdults",
+      "Yearlings",
+      "Calves"
+    )
+    placeholder <- rowSums(is.na(data[measurement_cols])) ==
+      length(measurement_cols)
     population_names <- unique(data$PopulationName)
     if (any(placeholder)) {
       unobserved_years <- caribou_year(
@@ -43,7 +50,10 @@ model_data_recruitment <- function(
   if (allow_missing && nrow(data) == 0L) {
     all_years <- sort(unique(as.character(unobserved_years)))
     data <- data.frame(
-      PopulationName = factor(character(), levels = as.character(population_names)),
+      PopulationName = factor(
+        character(),
+        levels = as.character(population_names)
+      ),
       Annual = factor(character(), levels = all_years),
       CaribouYear = integer(),
       Cows = integer(),

--- a/R/model-survival.R
+++ b/R/model-survival.R
@@ -24,8 +24,13 @@ model_data_survival <- function(
   quiet
 ) {
   if (allow_missing) {
-    measurement_cols <- c("StartTotal", "MortalitiesCertain", "MortalitiesUncertain")
-    placeholder <- rowSums(is.na(data[measurement_cols])) == length(measurement_cols)
+    measurement_cols <- c(
+      "StartTotal",
+      "MortalitiesCertain",
+      "MortalitiesUncertain"
+    )
+    placeholder <- rowSums(is.na(data[measurement_cols])) ==
+      length(measurement_cols)
     population_names <- unique(data$PopulationName)
     if (any(placeholder)) {
       unobserved_years <- caribou_year(
@@ -44,7 +49,10 @@ model_data_survival <- function(
   if (allow_missing && nrow(data) == 0L) {
     all_years <- sort(unique(as.character(unobserved_years)))
     data <- data.frame(
-      PopulationName = factor(character(), levels = as.character(population_names)),
+      PopulationName = factor(
+        character(),
+        levels = as.character(population_names)
+      ),
       Annual = factor(character(), levels = all_years),
       Month = factor(integer(), levels = month_levels(year_start, 12L)),
       CaribouYear = integer(),

--- a/R/predict-growth.R
+++ b/R/predict-growth.R
@@ -50,8 +50,8 @@ predict_lambda <- function(survival, recruitment) {
     return(list(lambda = list(), data = data))
   }
 
-  sur <- sur[, , key_sur %in% key_rec, drop = FALSE]
-  rec <- rec[, , key_rec %in% key_sur, drop = FALSE]
+  sur <- sur[,, key_sur %in% key_rec, drop = FALSE]
+  rec <- rec[,, key_rec %in% key_sur, drop = FALSE]
   class(sur) <- "mcmcarray"
   class(rec) <- "mcmcarray"
 
@@ -76,7 +76,11 @@ predict_lambda <- function(survival, recruitment) {
 #' @references Hatter, Ian, and Wendy Bergerud. 1991. "Moose Recruitment, Adult
 #'   Mortality and Rate of Change" 27: 65–73.
 #' @family analysis
-bb_predict_growth_samples <- function(survival, recruitment, sex_ratio = deprecated()) {
+bb_predict_growth_samples <- function(
+  survival,
+  recruitment,
+  sex_ratio = deprecated()
+) {
   if (lifecycle::is_present(sex_ratio)) {
     lifecycle::deprecate_warn(
       "1.0.0",
@@ -271,7 +275,10 @@ bb_predict_population_change <- function(
   )
   coef$Month <- NULL
   start <- coef |>
-    dplyr::summarise(CaribouYear = min(.data$CaribouYear) - 1L, .by = "PopulationName") |>
+    dplyr::summarise(
+      CaribouYear = min(.data$CaribouYear) - 1L,
+      .by = "PopulationName"
+    ) |>
     dplyr::mutate(estimate = 1, lower = 1, upper = 1)
   coef <- rbind(start, coef)
   coef <- dplyr::arrange(coef, .data$PopulationName, .data$CaribouYear)

--- a/R/predict-trend.R
+++ b/R/predict-trend.R
@@ -36,7 +36,10 @@ predict_trend <- function(fit, derived_expr) {
 #' }
 #' @export
 #' @family analysis
-bb_predict_recruitment_trend_samples <- function(recruitment, sex_ratio = deprecated()) {
+bb_predict_recruitment_trend_samples <- function(
+  recruitment,
+  sex_ratio = deprecated()
+) {
   chkor_vld(.vld_fit(recruitment), .vld_fit_ml(recruitment))
   chk_s3_class(recruitment, "bboufit_recruitment")
   .chk_year_trend(recruitment)

--- a/R/priors.R
+++ b/R/priors.R
@@ -145,7 +145,11 @@ bb_priors_recruitment <- function() {
 #'
 #' # Pass to bb_fit_survival via priors argument
 #' # fit <- bb_fit_survival(data, priors = nat_s)
-bb_priors_survival_national <- function(anthro, fire_excl_anthro, annual = FALSE) {
+bb_priors_survival_national <- function(
+  anthro,
+  fire_excl_anthro,
+  annual = FALSE
+) {
   .chk_disturbance(anthro, fire_excl_anthro)
   chk_flag(annual)
   result <- bbouNationalPriors::bbouNationalPriors(

--- a/R/remove.R
+++ b/R/remove.R
@@ -40,7 +40,9 @@ remove_sum0 <- function(
   rows <- nrow(x) - nrow(x2)
   if (rows > 0 && !quiet) {
     cols_str <- chk::cc(cols, " and ")
-    cli::cli_inform("Removed {rows} row{?s} where columns {.field {cols_str}} sum to 0.")
+    cli::cli_inform(
+      "Removed {rows} row{?s} where columns {.field {cols_str}} sum to 0."
+    )
   }
   x2
 }

--- a/R/test-helpers.R
+++ b/R/test-helpers.R
@@ -23,7 +23,10 @@ save_png <- function(x, width = 400, height = 400) {
 
 save_csv <- function(x, digits = NULL) {
   if (!is.null(digits)) {
-    x <- dplyr::mutate(x, dplyr::across(dplyr::where(is.numeric), \(col) signif(col, digits)))
+    x <- dplyr::mutate(
+      x,
+      dplyr::across(dplyr::where(is.numeric), \(col) signif(col, digits))
+    )
   }
   path <- tempfile(fileext = ".csv")
   readr::write_csv(x, path)

--- a/R/utils.R
+++ b/R/utils.R
@@ -112,7 +112,9 @@ year_intercept <- function(x) {
     dplyr::filter(.data$any_morts)
 
   if (nrow(y) == 0) {
-    cli::cli_warn("All years have 0 mortalities. Estimation of confidence intervals may not be reliable.")
+    cli::cli_warn(
+      "All years have 0 mortalities. Estimation of confidence intervals may not be reliable."
+    )
     return(min(x$CaribouYear))
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,7 +12,9 @@
 # limitations under the License.
 
 .check_attached <- function(search_path = search()) {
-  if (!"package:nimble" %in% search_path || !"package:nimbleQuad" %in% search_path) {
+  if (
+    !"package:nimble" %in% search_path || !"package:nimbleQuad" %in% search_path
+  ) {
     cli::cli_abort(c(
       "{.pkg nimble} and {.pkg nimbleQuad} must be attached to the search path for model fitting.",
       "i" = "Use {.code library(bboutools)} instead of {.code bboutools::}."

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true

--- a/tests/testthat/test-model-code.R
+++ b/tests/testthat/test-model-code.R
@@ -65,7 +65,11 @@ test_that("clean_model_code unwraps redundant braces", {
 
 test_that("clean_model_code handles deeply nested braces", {
   code <- quote({
-    {{ x <- 1 }}
+    {
+      {
+        x <- 1
+      }
+    }
     y <- 2
   })
   result <- clean_model_code(code)

--- a/tests/testthat/test-plot-month.R
+++ b/tests/testthat/test-plot-month.R
@@ -41,8 +41,8 @@ test_that("plot_month.data.frame ML works", {
 
 test_that("plot_month.data.frame one row", {
   prediction <- tibble::tribble(
-    ~Month, ~estimate, ~lower, ~upper,
-    1L, 0.5, 0.4, 0.6
+    ~Month , ~estimate , ~lower , ~upper ,
+    1L     , 0.5       , 0.4    , 0.6
   )
 
   plot <- bb_plot_month(prediction)
@@ -52,8 +52,8 @@ test_that("plot_month.data.frame one row", {
 
 test_that("plot_month.data.frame no rows", {
   prediction <- tibble::tribble(
-    ~Month, ~estimate, ~lower, ~upper,
-    1L, 0.5, 0.4, 0.6
+    ~Month , ~estimate , ~lower , ~upper ,
+    1L     , 0.5       , 0.4    , 0.6
   )
 
   prediction <- prediction[-1, ]

--- a/tests/testthat/test-plot-year-trend-recruitment.R
+++ b/tests/testthat/test-plot-year-trend-recruitment.R
@@ -43,8 +43,8 @@ test_that("bb_plot_year_trend_recruitment.data.frame ML works", {
 
 test_that("bb_plot_year_trend_recruitment.data.frame no rows", {
   prediction <- tibble::tribble(
-    ~CaribouYear, ~estimate, ~lower, ~upper,
-    1L, 0.5, 0.4, 0.6
+    ~CaribouYear , ~estimate , ~lower , ~upper ,
+    1L           , 0.5       , 0.4    , 0.6
   )
 
   prediction <- prediction[-1, ]

--- a/tests/testthat/test-plot-year.R
+++ b/tests/testthat/test-plot-year.R
@@ -53,8 +53,8 @@ test_that("plot_year.data.frame ML works", {
 
 test_that("plot_year.data.frame one row", {
   prediction <- tibble::tribble(
-    ~CaribouYear, ~estimate, ~lower, ~upper,
-    1L, 0.5, 0.4, 0.6
+    ~CaribouYear , ~estimate , ~lower , ~upper ,
+    1L           , 0.5       , 0.4    , 0.6
   )
 
   plot <- bb_plot_year(prediction)
@@ -64,8 +64,8 @@ test_that("plot_year.data.frame one row", {
 
 test_that("plot_year.data.frame no rows", {
   prediction <- tibble::tribble(
-    ~CaribouYear, ~estimate, ~lower, ~upper,
-    1L, 0.5, 0.4, 0.6
+    ~CaribouYear , ~estimate , ~lower , ~upper ,
+    1L           , 0.5       , 0.4    , 0.6
   )
 
   prediction <- prediction[-1, ]

--- a/tests/testthat/test-priors-national.R
+++ b/tests/testthat/test-priors-national.R
@@ -33,15 +33,38 @@ test_that("higher anthro gives lower survival b0_mu", {
 
 test_that("annual = TRUE returns lower survival b0_mu than monthly", {
   monthly <- bb_priors_survival_national(anthro = 1, fire_excl_anthro = 1)
-  annual <- bb_priors_survival_national(anthro = 1, fire_excl_anthro = 1, annual = TRUE)
+  annual <- bb_priors_survival_national(
+    anthro = 1,
+    fire_excl_anthro = 1,
+    annual = TRUE
+  )
   expect_gt(monthly["b0_mu"], annual["b0_mu"])
 })
 
 test_that("validates disturbance inputs", {
-  expect_chk_error(bb_priors_survival_national(anthro = -1, fire_excl_anthro = 5))
-  expect_chk_error(bb_priors_survival_national(anthro = 101, fire_excl_anthro = 5))
-  expect_chk_error(bb_priors_survival_national(anthro = "a", fire_excl_anthro = 5))
-  expect_chk_error(bb_priors_survival_national(anthro = 60, fire_excl_anthro = 50))
-  expect_chk_error(bb_priors_recruitment_national(anthro = 50, fire_excl_anthro = -1))
-  expect_chk_error(bb_priors_survival_national(anthro = 50, fire_excl_anthro = 5, annual = NA))
+  expect_chk_error(bb_priors_survival_national(
+    anthro = -1,
+    fire_excl_anthro = 5
+  ))
+  expect_chk_error(bb_priors_survival_national(
+    anthro = 101,
+    fire_excl_anthro = 5
+  ))
+  expect_chk_error(bb_priors_survival_national(
+    anthro = "a",
+    fire_excl_anthro = 5
+  ))
+  expect_chk_error(bb_priors_survival_national(
+    anthro = 60,
+    fire_excl_anthro = 50
+  ))
+  expect_chk_error(bb_priors_recruitment_national(
+    anthro = 50,
+    fire_excl_anthro = -1
+  ))
+  expect_chk_error(bb_priors_survival_national(
+    anthro = 50,
+    fire_excl_anthro = 5,
+    annual = NA
+  ))
 })


### PR DESCRIPTION
Closes #107

Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)